### PR TITLE
Maven updates (license headers and readme)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
-# jesse
+# Jesse
 
 Tree-based algorithm to calculate graphlet densities of nodes in a graph using equations.
 
-Command-line use: java -jar jesse 
+## Usage
+Command-line use: `java -jar jesse-1.0.0.jar`
 
 In the command line, Jesse will then ask for the maximal graphlet size and needed files to count the orbits (either the included standard files or newly generated files), a graph file and a file to save the results. 
 
@@ -13,3 +14,13 @@ The results file contains the graphlet degrees of each node of the graph. Each l
 A 4 0 3 3
 
 would mean node 'A' touches orbit 0 (a single edge) 4 times, orbit 1 (an end node of a 3-node path) 0 times, and both orbit 2 (the middle node of a 3-node path) and 3 (the triangle) 3 times.
+
+
+## Compiling
+Compiling the jar-file is done using Maven:
+
+```
+$ mvn clean install
+```
+
+The resulting jar can be found in the `target` directory.

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,24 @@
 					<goal>update-project-license</goal>
 				</goals>
 			</execution>
+			<execution>
+				<id>headers</id>
+				<configuration>
+					<inceptionYear>2017</inceptionYear>
+					<organizationName>Intec/UGent - Ine Melckenbeeck</organizationName>
+					<canUpdateCopyright>false</canUpdateCopyright>
+					<projectName>Jesse</projectName>
+					<licenseName>gpl_v3</licenseName>
+					<verbose>true</verbose>
+					<roots>
+						<root>src</root>
+					</roots>
+				</configuration>
+				<phase>process-sources</phase>
+				<goals>
+					<goal>update-file-header</goal>
+				</goals>
+			</execution>
 		</executions>
 	</plugin>
     </plugins>
@@ -109,6 +127,9 @@
 									<goals>
 										<goal>
 											update-project-license
+										</goal>
+										<goal>
+											update-file-header
 										</goal>
 									</goals>
 								</pluginExecutionFilter>

--- a/src/codegenerating/CountingInterpreter.java
+++ b/src/codegenerating/CountingInterpreter.java
@@ -1,5 +1,27 @@
 package codegenerating;
 
+/*
+ * #%L
+ * Jesse
+ * %%
+ * Copyright (C) 2017 Intec/UGent - Ine Melckenbeeck
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
+
 import graph.DanglingElement;
 import graph.DanglingGraph;
 import orbits.OrbitIdentification;

--- a/src/codegenerating/DanglingInterpreter.java
+++ b/src/codegenerating/DanglingInterpreter.java
@@ -1,5 +1,27 @@
 package codegenerating;
 
+/*
+ * #%L
+ * Jesse
+ * %%
+ * Copyright (C) 2017 Intec/UGent - Ine Melckenbeeck
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
+
 import java.io.BufferedWriter;
 import java.io.FileWriter;
 import java.io.IOException;

--- a/src/codegenerating/NegativeCountException.java
+++ b/src/codegenerating/NegativeCountException.java
@@ -1,5 +1,27 @@
 package codegenerating;
 
+/*
+ * #%L
+ * Jesse
+ * %%
+ * Copyright (C) 2017 Intec/UGent - Ine Melckenbeeck
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
+
 public class NegativeCountException extends Exception {
 
 	/**

--- a/src/codegenerating/Test.java
+++ b/src/codegenerating/Test.java
@@ -1,5 +1,27 @@
 package codegenerating;
 
+/*
+ * #%L
+ * Jesse
+ * %%
+ * Copyright (C) 2017 Intec/UGent - Ine Melckenbeeck
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
+
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileWriter;

--- a/src/codegenerating/TreeInterpreter.java
+++ b/src/codegenerating/TreeInterpreter.java
@@ -1,5 +1,27 @@
 package codegenerating;
 
+/*
+ * #%L
+ * Jesse
+ * %%
+ * Copyright (C) 2017 Intec/UGent - Ine Melckenbeeck
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
+
 import tree.AddEdgeNode;
 import tree.AddNodeNode;
 import tree.ConditionNode;

--- a/src/codegenerating/UI.java
+++ b/src/codegenerating/UI.java
@@ -1,5 +1,27 @@
 package codegenerating;
 
+/*
+ * #%L
+ * Jesse
+ * %%
+ * Copyright (C) 2017 Intec/UGent - Ine Melckenbeeck
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
+
 import java.io.IOException;
 import java.net.URL;
 import java.util.Scanner;

--- a/src/equations/Equation.java
+++ b/src/equations/Equation.java
@@ -1,5 +1,27 @@
 package equations;
 
+/*
+ * #%L
+ * Jesse
+ * %%
+ * Copyright (C) 2017 Intec/UGent - Ine Melckenbeeck
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
+
 import java.util.*;
 
 import orbits.Edge;

--- a/src/equations/EquationComparator.java
+++ b/src/equations/EquationComparator.java
@@ -1,5 +1,27 @@
 package equations;
 
+/*
+ * #%L
+ * Jesse
+ * %%
+ * Copyright (C) 2017 Intec/UGent - Ine Melckenbeeck
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
+
 import java.util.Comparator;
 
 

--- a/src/equations/EquationGenerator.java
+++ b/src/equations/EquationGenerator.java
@@ -1,5 +1,27 @@
 package equations;
 
+/*
+ * #%L
+ * Jesse
+ * %%
+ * Copyright (C) 2017 Intec/UGent - Ine Melckenbeeck
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
+
 import java.util.*;
 
 import orbits.OrbitRepresentative;

--- a/src/equations/EquationManager.java
+++ b/src/equations/EquationManager.java
@@ -1,5 +1,27 @@
 package equations;
 
+/*
+ * #%L
+ * Jesse
+ * %%
+ * Copyright (C) 2017 Intec/UGent - Ine Melckenbeeck
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
+
 import java.io.BufferedWriter;
 import java.io.FileWriter;
 import java.io.IOException;

--- a/src/equations/GeneticEquationManager.java
+++ b/src/equations/GeneticEquationManager.java
@@ -1,5 +1,27 @@
 package equations;
 
+/*
+ * #%L
+ * Jesse
+ * %%
+ * Copyright (C) 2017 Intec/UGent - Ine Melckenbeeck
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
+
 public class GeneticEquationManager {
 
 }

--- a/src/equations/LHSLengthComparator.java
+++ b/src/equations/LHSLengthComparator.java
@@ -1,5 +1,27 @@
 package equations;
 
+/*
+ * #%L
+ * Jesse
+ * %%
+ * Copyright (C) 2017 Intec/UGent - Ine Melckenbeeck
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
+
 import java.util.Comparator;
 
 public class LHSLengthComparator implements Comparator<Equation> {

--- a/src/equations/RHSLengthComparator.java
+++ b/src/equations/RHSLengthComparator.java
@@ -1,5 +1,27 @@
 package equations;
 
+/*
+ * #%L
+ * Jesse
+ * %%
+ * Copyright (C) 2017 Intec/UGent - Ine Melckenbeeck
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
+
 import java.util.Comparator;
 
 public class RHSLengthComparator implements Comparator<Equation> {

--- a/src/equations/RHSTermComparator.java
+++ b/src/equations/RHSTermComparator.java
@@ -1,5 +1,27 @@
 package equations;
 
+/*
+ * #%L
+ * Jesse
+ * %%
+ * Copyright (C) 2017 Intec/UGent - Ine Melckenbeeck
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
+
 import java.util.Comparator;
 
 public class RHSTermComparator implements Comparator<Equation> {

--- a/src/equations/RandomEquationManager.java
+++ b/src/equations/RandomEquationManager.java
@@ -1,5 +1,27 @@
 package equations;
 
+/*
+ * #%L
+ * Jesse
+ * %%
+ * Copyright (C) 2017 Intec/UGent - Ine Melckenbeeck
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
+
 public class RandomEquationManager extends EquationManager {
 	public RandomEquationManager(int order) {
 		super(order);

--- a/src/equations/SelectiveEquationManager.java
+++ b/src/equations/SelectiveEquationManager.java
@@ -1,5 +1,27 @@
 package equations;
 
+/*
+ * #%L
+ * Jesse
+ * %%
+ * Copyright (C) 2017 Intec/UGent - Ine Melckenbeeck
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
+
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;

--- a/src/graph/DanglingElement.java
+++ b/src/graph/DanglingElement.java
@@ -1,5 +1,27 @@
 package graph;
 
+/*
+ * #%L
+ * Jesse
+ * %%
+ * Copyright (C) 2017 Intec/UGent - Ine Melckenbeeck
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
+
 /**
  * Element in a DanglingList. 
  * 

--- a/src/graph/DanglingGraph.java
+++ b/src/graph/DanglingGraph.java
@@ -1,5 +1,27 @@
 package graph;
 
+/*
+ * #%L
+ * Jesse
+ * %%
+ * Copyright (C) 2017 Intec/UGent - Ine Melckenbeeck
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
+
 import java.io.FileNotFoundException;
 import java.io.PrintWriter;
 import java.io.UnsupportedEncodingException;

--- a/src/graph/DanglingIterator.java
+++ b/src/graph/DanglingIterator.java
@@ -1,5 +1,27 @@
 package graph;
 
+/*
+ * #%L
+ * Jesse
+ * %%
+ * Copyright (C) 2017 Intec/UGent - Ine Melckenbeeck
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
+
 import java.util.Iterator;
 
 /**

--- a/src/graph/DanglingList.java
+++ b/src/graph/DanglingList.java
@@ -1,5 +1,27 @@
 package graph;
 
+/*
+ * #%L
+ * Jesse
+ * %%
+ * Copyright (C) 2017 Intec/UGent - Ine Melckenbeeck
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
+
 import java.util.Iterator;
 import java.util.Stack;
 

--- a/src/graph/GraphReader.java
+++ b/src/graph/GraphReader.java
@@ -1,5 +1,27 @@
 package graph;
 
+/*
+ * #%L
+ * Jesse
+ * %%
+ * Copyright (C) 2017 Intec/UGent - Ine Melckenbeeck
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
+
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.util.ArrayList;

--- a/src/graphletgenerating/Graph.java
+++ b/src/graphletgenerating/Graph.java
@@ -1,4 +1,26 @@
 package graphletgenerating;
+
+/*
+ * #%L
+ * Jesse
+ * %%
+ * Copyright (C) 2017 Intec/UGent - Ine Melckenbeeck
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
 import java.util.*;
 
 public class Graph {

--- a/src/graphletgenerating/Permutator.java
+++ b/src/graphletgenerating/Permutator.java
@@ -1,4 +1,26 @@
 package graphletgenerating;
+
+/*
+ * #%L
+ * Jesse
+ * %%
+ * Copyright (C) 2017 Intec/UGent - Ine Melckenbeeck
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
 import java.util.*;
 
 public class Permutator {

--- a/src/graphletgenerating/Program.java
+++ b/src/graphletgenerating/Program.java
@@ -1,5 +1,27 @@
 package graphletgenerating;
 
+/*
+ * #%L
+ * Jesse
+ * %%
+ * Copyright (C) 2017 Intec/UGent - Ine Melckenbeeck
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
+
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;

--- a/src/orbits/Edge.java
+++ b/src/orbits/Edge.java
@@ -1,5 +1,27 @@
 package orbits;
 
+/*
+ * #%L
+ * Jesse
+ * %%
+ * Copyright (C) 2017 Intec/UGent - Ine Melckenbeeck
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
+
 import java.util.Arrays;
 
 import equations.EquationGenerator;

--- a/src/orbits/OrbitIdentification.java
+++ b/src/orbits/OrbitIdentification.java
@@ -1,5 +1,27 @@
 package orbits;
 
+/*
+ * #%L
+ * Jesse
+ * %%
+ * Copyright (C) 2017 Intec/UGent - Ine Melckenbeeck
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
+
 //import Edge;
 
 import java.io.File;

--- a/src/orbits/OrbitRepresentative.java
+++ b/src/orbits/OrbitRepresentative.java
@@ -1,5 +1,27 @@
 package orbits;
 
+/*
+ * #%L
+ * Jesse
+ * %%
+ * Copyright (C) 2017 Intec/UGent - Ine Melckenbeeck
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
+
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;

--- a/src/progress/TaskMonitor.java
+++ b/src/progress/TaskMonitor.java
@@ -1,5 +1,27 @@
 package progress;
 
+/*
+ * #%L
+ * Jesse
+ * %%
+ * Copyright (C) 2017 Intec/UGent - Ine Melckenbeeck
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
+
 /**
  * Lightweight task monitor interface to allow methods to report their 
  * progress to a client. 

--- a/src/tree/AddEdgeNode.java
+++ b/src/tree/AddEdgeNode.java
@@ -1,5 +1,27 @@
 package tree;
 
+/*
+ * #%L
+ * Jesse
+ * %%
+ * Copyright (C) 2017 Intec/UGent - Ine Melckenbeeck
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
+
 import java.util.ArrayList;
 import java.util.List;
 import orbits.OrbitRepresentative;

--- a/src/tree/AddNode.java
+++ b/src/tree/AddNode.java
@@ -1,5 +1,27 @@
 package tree;
 
+/*
+ * #%L
+ * Jesse
+ * %%
+ * Copyright (C) 2017 Intec/UGent - Ine Melckenbeeck
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
+
 import orbits.OrbitRepresentative;
 
 /**

--- a/src/tree/AddNodeNode.java
+++ b/src/tree/AddNodeNode.java
@@ -1,5 +1,27 @@
 package tree;
 
+/*
+ * #%L
+ * Jesse
+ * %%
+ * Copyright (C) 2017 Intec/UGent - Ine Melckenbeeck
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.SortedMap;

--- a/src/tree/ConditionNode.java
+++ b/src/tree/ConditionNode.java
@@ -1,5 +1,27 @@
 package tree;
 
+/*
+ * #%L
+ * Jesse
+ * %%
+ * Copyright (C) 2017 Intec/UGent - Ine Melckenbeeck
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
+
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/tree/OrbitTree.java
+++ b/src/tree/OrbitTree.java
@@ -1,5 +1,27 @@
 package tree;
 
+/*
+ * #%L
+ * Jesse
+ * %%
+ * Copyright (C) 2017 Intec/UGent - Ine Melckenbeeck
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
+
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileNotFoundException;

--- a/src/tree/TreeNode.java
+++ b/src/tree/TreeNode.java
@@ -1,5 +1,27 @@
 package tree;
 
+/*
+ * #%L
+ * Jesse
+ * %%
+ * Copyright (C) 2017 Intec/UGent - Ine Melckenbeeck
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
+
 import java.util.List;
 
 /**


### PR DESCRIPTION
Maven has been updated to maintain license headers for all `.java` files and the `README.md` has been extended with some compiling instructions.   
All source files now start with a GPL3 header.